### PR TITLE
Recipe deprecations

### DIFF
--- a/Disk Inventory X/DiskInventoryX.download.recipe
+++ b/Disk Inventory X/DiskInventoryX.download.recipe
@@ -19,6 +19,24 @@
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been replaced by: https://github.com/autopkg/dataJAR-recipes/tree/master/Disk%20Inventory%20X. Please use the recipes in te dataJAR-recipes repo instead.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/DraftSight/DraftSight.download.recipe
+++ b/DraftSight/DraftSight.download.recipe
@@ -19,6 +19,24 @@
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been replaced by: https://github.com/autopkg/dataJAR-recipes/tree/master/DraftSight. Please use the recipes in te dataJAR-recipes repo instead.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Evolus Pencil/EvolusPencil.download.recipe
+++ b/Evolus Pencil/EvolusPencil.download.recipe
@@ -17,6 +17,24 @@
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been replaced by: https://github.com/autopkg/dataJAR-recipes/tree/master/Pencil. Please use the recipes in te dataJAR-recipes repo instead.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Gambit/Gambit.download.recipe
+++ b/Gambit/Gambit.download.recipe
@@ -17,6 +17,24 @@
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated, as this title has not been updated since 2017.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>SourceForgeURLProvider</string>

--- a/OpenToonz/opentoonz.munki.recipe
+++ b/OpenToonz/opentoonz.munki.recipe
@@ -42,6 +42,24 @@
 	<string>com.github.rustymyers.download.opentoonz</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been replaced by: https://github.com/autopkg/dataJAR-recipes/blob/master/OpenToonz/OpenToonz.munki.recipel. Please use the recipes in te dataJAR-recipes repo instead.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Poll Everywhere, Inc./PollEv Presenter.download.recipe
+++ b/Poll Everywhere, Inc./PollEv Presenter.download.recipe
@@ -19,6 +19,24 @@
 	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
+         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been replaced by: https://github.com/autopkg/dataJAR-recipes/tree/master/Poll%20Everywhere. Please use the recipes in te dataJAR-recipes repo instead.</string>
+            </dict>
+        </dict>
+        <dict>   
+            <key>Processor</key>   
+            <string>StopProcessingIf</string>   
+            <key>Arguments</key>   
+            <dict>   
+                <key>predicate</key>   
+                <string>TRUEPREDICATE</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Migrated recipes to the dataJAR-Recipes repo, as this repo seems to no longer be active.

DeprecationWarning with a note pointing to the new recipes added to all except Gambit, which has not been updated since 2017.